### PR TITLE
Fix windows build linkage issues.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,18 @@ set( ABSL_PUBLIC_LIBRARIES
     absl_utility
 )
 
+set (ABSL_INTERNAL_LIBRARIES)
+if (MSVC)
+    set( ABSL_INTERNAL_LIBRARIES
+        absl_internal_malloc_internal
+        absl_internal_spinlock_wait
+        absl_internal_throw_delegate
+    )
+endif()
+
 catkin_package(
    INCLUDE_DIRS ./abseil_cpp
-   LIBRARIES ${ABSL_PUBLIC_LIBRARIES}
+   LIBRARIES ${ABSL_PUBLIC_LIBRARIES} ${ABSL_INTERNAL_LIBRARIES}
 )
 
 add_subdirectory(abseil_cpp)

--- a/abseil_cpp/CMake/AbseilHelpers.cmake
+++ b/abseil_cpp/CMake/AbseilHelpers.cmake
@@ -204,6 +204,7 @@ function(absl_header_library)
 
   add_library(${_NAME} ${__dummy_header_only_lib_file})
   target_link_libraries(${_NAME} PUBLIC ${ABSL_HO_LIB_PUBLIC_LIBRARIES})
+  set_target_properties(${_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
   target_include_directories(${_NAME}
     PUBLIC ${ABSL_COMMON_INCLUDE_DIRS} ${ABSL_HO_LIB_PUBLIC_INCLUDE_DIRS}
     PRIVATE ${ABSL_HO_LIB_PRIVATE_INCLUDE_DIRS}


### PR DESCRIPTION
* By default all abseil_cpp libraries built as STATIC and the absl_internal_* won't be automatically merged with the exported libraries. For example, absl_string.lib won't have the compiled objects of absl_internal_throw_delegate.lib, and the caller will need to explicitly link against absl_internal_throw_delegate.lib to fulfill the linkage dependencies. The approach I chose here is to expose them as abseil_cpp libraries so the downstream projects will get them added to linker options automatically.

* The absl_header_library needs WINDOWS_EXPORT_ALL_SYMBOLS to generate imported library for the dummy DLL.